### PR TITLE
Fix "Assert.dependencies is not a function"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-let Verify, Assert;
+let Verify, Dependencies;
 // laravel-mix@1.x
 try { Verify = require('laravel-mix/src/Verify'); }
 // laravel-mix@>=2.x
-catch (e) { Assert = require('laravel-mix/src/Assert'); }
+catch (e) { Dependencies = require('laravel-mix/src/Dependencies'); }
 
 const notifier = require('node-notifier');
 const glob = require('glob');
@@ -12,7 +12,7 @@ function pug(src, dest, options = {}) {
     // laravel-mix@1.x
     if (Verify != null) Verify.dependency('pug', ['pug'], true);
     // laravel-mix@>=2.x
-    else Assert.dependencies(['pug'], true);
+    else new Dependencies(['pug']).install(true);
 
     let globOption = options.glob ? options.glob : {}
     let files = glob.sync(src, globOption);


### PR DESCRIPTION
starting from version 6.0.38 laravel-mix/Assert.js remove "dependencies" function